### PR TITLE
Vertical aligned attribute values

### DIFF
--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -289,6 +289,39 @@ function perform_indentation(lines) {
     return indented_lines;
 }
 
+function perform_alignment(lines) {
+    var all_lines = [], attribute_lines = [], iterator1 = lines, line, minAlignColumn = 0;
+    for (let index1 = 0; index1 < iterator1.length; index1++) {
+        line = iterator1[index1];
+        if (line !== "" && 
+        !line.endsWith("{") && 
+        !line.startsWith("#") && 
+        !line.endsWith("}") &&
+        !line.trim().startsWith("upstream") &&
+        !line.trim().contains("location")) {
+            const splitLine = line.match(/\S+/g);
+            if (splitLine.length > 1) {
+                attribute_lines.push(line);
+                const columnAtAttrValue = line.indexOf(splitLine[1])+1;
+                if (minAlignColumn < columnAtAttrValue) {
+                    minAlignColumn = columnAtAttrValue;
+                }
+            }
+        } 
+        all_lines.push(line);
+    }
+    for (let index1 = 0; index1 < all_lines.length; index1++) {
+        line = all_lines[index1];
+        if (attribute_lines.includes(line)) {
+            const split = line.match(/\S+/g);
+            const indent = line.match(/\s+/g)[0];
+            line = indent + split[0] + " ".repeat(minAlignColumn - split[0].length - indent.length) + split.slice(1, split.length).join(" ");
+            all_lines[index1] = line;
+        }
+    }
+
+    return all_lines;
+}
 
 /**nodejs relevant**/
 // List all files in a directory in Node.js recursively in a synchronous fashion

--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -318,6 +318,7 @@ var options = {
         tabs: 0,
         dontJoinCurlyBracet: false,
         trailingBlankLines: false,
+        align: false,
         recursive: false,
         inputPath: [],
         outputPath: [],
@@ -402,6 +403,12 @@ var knownArguments = {
             options.dontJoinCurlyBracet = true;
         }
         ,
+        "--align": function (input) {
+            if (input == "desc")
+                return "if set to true, all applicable attribute values will be vertically aligned with each other";
+            options.align = true;
+        }
+        ,
         "--recursive": function (input) {
             if (input == "desc")
                 return "scan the whole current folder, and all sub folders recursively.";
@@ -458,6 +465,7 @@ knownArguments["-o"] = knownArguments["--output"];
 knownArguments["-bl"] = knownArguments["--blank-lines"];
 knownArguments["--dontjoin"] = knownArguments["--dont-join"];
 knownArguments["-dj"] = knownArguments["--dont-join"];
+knownArguments["-a"] = knownArguments["--align"];
 knownArguments["-ext"] = knownArguments["--extension"];
 knownArguments["-e"] = knownArguments["--extension"];
 var wasFunc = null;
@@ -537,8 +545,13 @@ for (var index = 0, length = filesArr.length; index < length; index++) {
     //join opening bracket(if user wishes so) true by default
     if (!options.dontJoinCurlyBracet)
         cleanLines = join_opening_bracket(cleanLines);
-    //perform the final indentation
-    cleanLines = perform_indentation(cleanLines);
+    //perform the indentation
+    cleanLines = perform_indentation(cleanLines);    
+    // vertically align all eligible declarations
+    if (options.align) {
+        cleanLines = perform_alignment(cleanLines);
+    }
+
     //combine all the lines back together
     var outputContents = cleanLines.join("\n");
     //save all the contents to the file.

--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -255,7 +255,7 @@ function join_opening_bracket(lines) {
             //just make sure we don't put anything before 0
             if (i >= 1) {
                 lines[i] = lines[i - 1] + " {";
-                if (NEWLINEAFTERBRACET && lines.length > (i + 1) && lines[i + 1].length > 0)
+                if (options.trailingBlankLines && lines.length > (i + 1) && lines[i + 1].length > 0)
                     lines.insert(i + 1, "");
                 lines.remove(i - 1);
             }
@@ -265,7 +265,6 @@ function join_opening_bracket(lines) {
 }
 
 var INDENTATION = '\t';
-var NEWLINEAFTERBRACET = true;
 
 function perform_indentation(lines) {
     var indented_lines, current_indent, line;
@@ -318,6 +317,7 @@ var options = {
         spaces: 0,
         tabs: 0,
         dontJoinCurlyBracet: false,
+        trailingBlankLines: false,
         recursive: false,
         inputPath: [],
         outputPath: [],
@@ -391,6 +391,11 @@ var knownArguments = {
             options.tabs = parseInt(number);
             INDENTATION = "\t".repeat(options.tabs);
         },
+        "--blank-lines": function (input) {
+            if (input == "desc") 
+                return "if set to true, an empty line will be inserted after opening brackets";
+            options.trailingBlankLines = true;
+        },
         "--dont-join": function (input) {
             if (input == "desc")
                 return "if set to true, commands such as 'server' and '{' will be on a seperate line, false by default ('server {' )";
@@ -450,6 +455,7 @@ knownArguments["-t"] = knownArguments["--tabs"];
 knownArguments["-r"] = knownArguments["--recursive"];
 knownArguments["-i"] = knownArguments["--input"];
 knownArguments["-o"] = knownArguments["--output"];
+knownArguments["-bl"] = knownArguments["--blank-lines"];
 knownArguments["--dontjoin"] = knownArguments["--dont-join"];
 knownArguments["-dj"] = knownArguments["--dont-join"];
 knownArguments["-ext"] = knownArguments["--extension"];

--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -293,21 +293,21 @@ function perform_alignment(lines) {
     var all_lines = [], attribute_lines = [], iterator1 = lines, line, minAlignColumn = 0;
     for (let index1 = 0; index1 < iterator1.length; index1++) {
         line = iterator1[index1];
-        if (line !== "" && 
-        !line.endsWith("{") && 
-        !line.startsWith("#") && 
-        !line.endsWith("}") &&
-        !line.trim().startsWith("upstream") &&
-        !line.trim().contains("location")) {
+        if (line !== "" &&
+            !line.endsWith("{") &&
+            !line.startsWith("#") &&
+            !line.endsWith("}") &&
+            !line.trim().startsWith("upstream") &&
+            !line.trim().contains("location")) {
             const splitLine = line.match(/\S+/g);
             if (splitLine.length > 1) {
                 attribute_lines.push(line);
-                const columnAtAttrValue = line.indexOf(splitLine[1])+1;
+                const columnAtAttrValue = line.indexOf(splitLine[1]) + 1;
                 if (minAlignColumn < columnAtAttrValue) {
                     minAlignColumn = columnAtAttrValue;
                 }
             }
-        } 
+        }
         all_lines.push(line);
     }
     for (let index1 = 0; index1 < all_lines.length; index1++) {
@@ -356,9 +356,7 @@ var options = {
         inputPath: [],
         outputPath: [],
         extension: "conf"
-
-    }
-;
+};
 
 
 var knownArguments = {

--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -255,7 +255,7 @@ function join_opening_bracket(lines) {
             //just make sure we don't put anything before 0
             if (i >= 1) {
                 lines[i] = lines[i - 1] + " {";
-                if (options.trailingBlankLines && lines.length > (i + 1) && lines[i + 1].length > 0)
+                if (NEWLINEAFTERBRACET && lines.length > (i + 1) && lines[i + 1].length > 0)
                     lines.insert(i + 1, "");
                 lines.remove(i - 1);
             }
@@ -265,6 +265,7 @@ function join_opening_bracket(lines) {
 }
 
 var INDENTATION = '\t';
+var NEWLINEAFTERBRACET = true;
 
 function perform_indentation(lines) {
     var indented_lines, current_indent, line;
@@ -350,7 +351,6 @@ var options = {
         spaces: 0,
         tabs: 0,
         dontJoinCurlyBracet: false,
-        trailingBlankLines: false,
         align: false,
         recursive: false,
         inputPath: [],
@@ -423,11 +423,6 @@ var knownArguments = {
             options.tabs = parseInt(number);
             INDENTATION = "\t".repeat(options.tabs);
         },
-        "--blank-lines": function (input) {
-            if (input == "desc") 
-                return "if set to true, an empty line will be inserted after opening brackets";
-            options.trailingBlankLines = true;
-        },
         "--dont-join": function (input) {
             if (input == "desc")
                 return "if set to true, commands such as 'server' and '{' will be on a seperate line, false by default ('server {' )";
@@ -493,7 +488,6 @@ knownArguments["-t"] = knownArguments["--tabs"];
 knownArguments["-r"] = knownArguments["--recursive"];
 knownArguments["-i"] = knownArguments["--input"];
 knownArguments["-o"] = knownArguments["--output"];
-knownArguments["-bl"] = knownArguments["--blank-lines"];
 knownArguments["--dontjoin"] = knownArguments["--dont-join"];
 knownArguments["-dj"] = knownArguments["--dont-join"];
 knownArguments["-a"] = knownArguments["--align"];


### PR DESCRIPTION
# Overview
Vertically aligns the values for attributes within `{ }` blocks. There are no unit tests configured in this project (which might be worth adding) so my only confirmation is that it perfectly formats *_my_* nginx confs, but let me know if I missed some edge cases.

## Assumptions
* You don't want to vertically align anything in lines like `location {` or `upstream server-name {`, but you do want to vertically align the attribute value (which comes after a single-word attribute name). 
* Not 100% sure about double-width characters or how that might come into play

### Examples

*Before*
```nginx
upstream rtsp-upstream {
  server 192.168.1.1:7447;
}

server {
  listen 443 ssl http2;
  listen 7443 ssl http2;
  server_name subd.domain.tv;
  access_log /var/log/nginx/subd.access.log;
  error_log /var/log/nginx/subd.error.log;
}
```
*After*
```nginx

upstream rtsp-upstream {
  server                  192.168.1.63:7447;
}

server {
  listen                  443 ssl http2;
  listen                  7443 ssl http2;
  server_name             subd.domain.tv;
  access_log              /var/log/nginx/subd.access.log;
  error_log               /var/log/nginx/subd.error.log;
}
```

## How to use it
|Short arg|Long arg| What it does |
|--|--|--|
|`-a`|`--align`| Vertically aligns attribute values|

Resolves #6