### PR TITLE
Make "blank lines after curly" a configurable option

### DIFF
--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -255,7 +255,7 @@ function join_opening_bracket(lines) {
             //just make sure we don't put anything before 0
             if (i >= 1) {
                 lines[i] = lines[i - 1] + " {";
-                if (NEWLINEAFTERBRACET && lines.length > (i + 1) && lines[i + 1].length > 0)
+                if (options.trailingBlankLines && lines.length > (i + 1) && lines[i + 1].length > 0)
                     lines.insert(i + 1, "");
                 lines.remove(i - 1);
             }
@@ -265,7 +265,6 @@ function join_opening_bracket(lines) {
 }
 
 var INDENTATION = '\t';
-var NEWLINEAFTERBRACET = true;
 
 function perform_indentation(lines) {
     var indented_lines, current_indent, line;
@@ -318,6 +317,7 @@ var options = {
         spaces: 0,
         tabs: 0,
         dontJoinCurlyBracet: false,
+        trailingBlankLines: false,
         recursive: false,
         inputPath: [],
         outputPath: [],
@@ -391,6 +391,11 @@ var knownArguments = {
             options.tabs = parseInt(number);
             INDENTATION = "\t".repeat(options.tabs);
         },
+        "--blank-lines": function (input) {
+            if (input == "desc") 
+                return "if set to true, an empty line will be inserted after opening brackets";
+            options.trailingBlankLines = true;
+        },
         "--dont-join": function (input) {
             if (input == "desc")
                 return "if set to true, commands such as 'server' and '{' will be on a seperate line, false by default ('server {' )";
@@ -450,6 +455,7 @@ knownArguments["-t"] = knownArguments["--tabs"];
 knownArguments["-r"] = knownArguments["--recursive"];
 knownArguments["-i"] = knownArguments["--input"];
 knownArguments["-o"] = knownArguments["--output"];
+knownArguments["-bl"] = knownArguments["--blank-lines"];
 knownArguments["--dontjoin"] = knownArguments["--dont-join"];
 knownArguments["-dj"] = knownArguments["--dont-join"];
 knownArguments["-ext"] = knownArguments["--extension"];


### PR DESCRIPTION
# Overview
I noticed that `NEWLINEAFTERBRACET` was just hardcoded to `true`, but I personally think it's strange looking. I do not commonly see this used, either. While this does change the default behavior (from true to false, effectively), I can change that back but I will need to have another go at the argument naming conventions. 

Including `--blank-lines` makes it `true`, omitting it leaves it `false`. If flipped, I could see changing it to `--no-blank-lines`|`-nbl`. 

## Assumptions
No change in behavior here, but it is worth noting that using `--blank-lines` will _add_ the blank lines after a curly bracket, but omitting the arg **will not remove existing blank lines**. 

## Examples

With `--blank-lines` | `-bl`
```nginx
upstream rtsp-upstream {

  server 192.168.1.63:7447;
}

server {

  listen 443 ssl http2;
  listen 7443 ssl http2;
  server_name subd.domain.tv;
  access_log /var/log/nginx/subd.access.log;
  error_log /var/log/nginx/subd.error.log;
}
```

Omitting the `--blank-lines` argument
```nginx

upstream rtsp-upstream {
  server 192.168.1.63:7447;
}

server {
  listen 443 ssl http2;
  listen 7443 ssl http2;
  server_name subd.domain.tv;
  access_log /var/log/nginx/subd.access.log;
  error_log /var/log/nginx/subd.error.log;
}
```

## How to use it
|Short arg|Long arg|What does it do|
|---|---|---|
|`-bl`|`--blank-lines`|If used, will insert a trailing blank line after an opening bracket|

