### PR TITLE
resolve #19

### DIFF
--- a/nginxbeautifier.js
+++ b/nginxbeautifier.js
@@ -219,6 +219,10 @@ function clean_lines(configContents) {
                 var startOfComment = line.indexOf("#");
                 var comment = startOfComment >= 0 ? line.slice(startOfComment) : "";
                 var code = startOfComment >= 0 ? line.slice(0, startOfComment) : line;
+
+                var removedDoubleQuatations = extractAllPossibleText(code, '"', '"');
+                code = removedDoubleQuatations.filteredInput;
+
                 var startOfParanthesis = code.indexOf("}");
                 if (startOfParanthesis >= 0) {
                     if (startOfParanthesis > 0) {
@@ -239,7 +243,10 @@ function clean_lines(configContents) {
                         splittedByLines.insert(index + 2, l2);
 
                 }
-                line = code;
+
+                removedDoubleQuatations.filteredInput = splittedByLines[index];
+                line = removedDoubleQuatations.getRestored();
+                splittedByLines[index] = line;
             }
         }
         //remove more than two newlines
@@ -251,7 +258,6 @@ function clean_lines(configContents) {
 
             }
         }
-
     }
     return splittedByLines;
 }


### PR DESCRIPTION
Problem reported on issue #16 happens when a regex contains `{}` characters as they are treated as an nginx block even though they are enclosed within `""`. The proposed fix consists on removing the `"whatever"` portions before checking for code blocks